### PR TITLE
Issue/222

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,4 +30,11 @@ export default defineConfig([
       "react/no-unescaped-entities": "off",
     },
   },
+  {
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+  },
 ]);

--- a/src/components/beatmapSet/beatmapList.tsx
+++ b/src/components/beatmapSet/beatmapList.tsx
@@ -77,7 +77,9 @@ const BeatmapList = ({
             .sort((a, b) => a.difficulty_rating - b.difficulty_rating)
             .map((beatmap) => {
               const beatmapScores =
-                highScores[beatmapSet.id]?.[beatmap.id] ?? [];
+                beatmapSet.status === "local"
+                  ? []
+                  : (highScores[beatmapSet.id]?.[beatmap.id] ?? []);
 
               return (
                 <div key={beatmap.id}>

--- a/src/components/beatmapSet/beatmapPageButton.tsx
+++ b/src/components/beatmapSet/beatmapPageButton.tsx
@@ -8,6 +8,10 @@ import { ExternalLink } from "lucide-react";
 import { Button } from "../ui/button";
 
 const BeatmapSetPageButton = ({ beatmapSetId }: { beatmapSetId: number }) => {
+  if (beatmapSetId <= 0) {
+    return null;
+  }
+
   return (
     <TooltipProvider>
       <Tooltip delayDuration={0}>
@@ -20,7 +24,8 @@ const BeatmapSetPageButton = ({ beatmapSetId }: { beatmapSetId: number }) => {
           >
             <a
               href={`https://osu.ppy.sh/beatmapsets/${beatmapSetId}`}
-              target="_blank" rel="noreferrer"
+              target="_blank"
+              rel="noreferrer"
             >
               <ExternalLink className="size-5" />
             </a>

--- a/src/components/beatmapSet/beatmapPageButton.tsx
+++ b/src/components/beatmapSet/beatmapPageButton.tsx
@@ -8,10 +8,6 @@ import { ExternalLink } from "lucide-react";
 import { Button } from "../ui/button";
 
 const BeatmapSetPageButton = ({ beatmapSetId }: { beatmapSetId: number }) => {
-  if (beatmapSetId <= 0) {
-    return null;
-  }
-
   return (
     <TooltipProvider>
       <Tooltip delayDuration={0}>

--- a/src/components/beatmapSet/beatmapSet.tsx
+++ b/src/components/beatmapSet/beatmapSet.tsx
@@ -96,7 +96,9 @@ const BeatmapSet = ({ beatmapSet }: { beatmapSet: BeatmapSetData }) => {
 
         <div className="absolute top-4 right-4 flex gap-2">
           <CollectionsDropdown beatmapSet={beatmapSet} />
-          <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
+          {beatmapSet.status !== "local" && (
+            <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
+          )}
         </div>
       </div>
 

--- a/src/components/beatmapSet/beatmapSet.tsx
+++ b/src/components/beatmapSet/beatmapSet.tsx
@@ -94,12 +94,12 @@ const BeatmapSet = ({ beatmapSet }: { beatmapSet: BeatmapSetData }) => {
           <IndexedDbButton beatmapSet={beatmapSet} />
         </div>
 
-        <div className="absolute top-4 right-4 flex gap-2">
-          <CollectionsDropdown beatmapSet={beatmapSet} />
-          {beatmapSet.status !== "local" && (
+        {beatmapSet.id > 0 && (
+          <div className="absolute top-4 right-4 flex gap-2">
+            <CollectionsDropdown beatmapSet={beatmapSet} />
             <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
-          )}
-        </div>
+          </div>
+        )}
       </div>
 
       <PopoverContent className="p-0">

--- a/src/components/beatmapSet/beatmapSetCover.tsx
+++ b/src/components/beatmapSet/beatmapSetCover.tsx
@@ -20,6 +20,8 @@ const getStatusClass = (status: Status) => {
       return "bg-[#ff9966] text-[#394246]"; // Orange
     case "graveyard":
       return "bg-black text-[#5c6970]"; // Gray
+    case "local":
+      return "bg-[#8ad4ff] text-[#1f2a33]"; // Cyan
   }
 };
 
@@ -31,11 +33,12 @@ const BeatmapSetCover = ({ beatmapSet }: { beatmapSet: BeatmapSet }) => {
   const preferMetadataInOriginalLanguage =
     useSettingsStore.use.preferMetadataInOriginalLanguage();
 
-  const coverUrl = (
-    beatmapCoverProvider !== "Custom"
+  const coverUrl =
+    beatmapSet.coverUrl ??
+    (beatmapCoverProvider !== "Custom"
       ? BEATMAP_COVER_PROVIDERS[beatmapCoverProvider]
       : customBeatmapCoverProvider
-  ).replace("$setId", beatmapSet.id.toString());
+    ).replace("$setId", beatmapSet.id.toString());
 
   const artist = preferMetadataInOriginalLanguage
     ? beatmapSet.artist_unicode

--- a/src/components/game/gameModal.tsx
+++ b/src/components/game/gameModal.tsx
@@ -15,6 +15,7 @@ const GameModal = () => {
   const beatmapId = useGameStore.use.beatmapId();
   const closeGame = useGameStore.use.closeGame();
   const uploadedBeatmapSet = useGameStore.use.uploadedBeatmapSet();
+  const localReplayBeatmapSet = useGameStore.use.localReplayBeatmapSet();
   const replayData = useGameStore.use.replayData();
   const storeDownloadedBeatmaps = useSettingsStore(
     (settings) => settings.storeDownloadedBeatmaps,
@@ -58,6 +59,8 @@ const GameModal = () => {
 
       if (uploadedBeatmapSet) {
         beatmapSetFile = uploadedBeatmapSet;
+      } else if (localReplayBeatmapSet) {
+        beatmapSetFile = localReplayBeatmapSet;
       } else {
         try {
           beatmapSetFile = await getBeatmapSet(
@@ -102,6 +105,7 @@ const GameModal = () => {
           beatmap,
           replayData?.mods,
           replayData?.columnMap,
+          beatmapSet.status === "local",
         );
 
         await loadAssets();
@@ -124,6 +128,7 @@ const GameModal = () => {
     closeGame,
     getBeatmapSet,
     uploadedBeatmapSet,
+    localReplayBeatmapSet,
     beatmapSet,
     storedBeatmapSets,
     setStoredBeatmapSets,

--- a/src/components/game/gameModal.tsx
+++ b/src/components/game/gameModal.tsx
@@ -115,7 +115,11 @@ const GameModal = () => {
         // If autoplay is enabled and we're not already watching a replay, use a perfect replay
         const mods = useSettingsStore.getState().mods;
         if (!replay && mods.autoplay) {
-          replay = generateAutoReplay(parsedBeatmapData, mods);
+          replay = generateAutoReplay(
+            parsedBeatmapData,
+            parsedBeatmapData.beatmapHash,
+            mods,
+          );
         }
 
         await loadAssets();

--- a/src/components/game/pauseScreen.tsx
+++ b/src/components/game/pauseScreen.tsx
@@ -65,8 +65,8 @@ const PauseScreen = ({
             </div>
 
             {beatmapSet && beatmapSet.id > 0 && (
-              <div className="absolute top-4 right-4 flex gap-2">
-                <CollectionsDropdown beatmapSet={beatmapSet} />
+              <div className="flex gap-2" data-exclude>
+                <CollectionsDropdown beatmapSet={beatmapSet} alwaysShow />
 
                 <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
               </div>

--- a/src/components/game/pauseScreen.tsx
+++ b/src/components/game/pauseScreen.tsx
@@ -68,7 +68,9 @@ const PauseScreen = ({
               <div className="flex gap-2" data-exclude>
                 <CollectionsDropdown beatmapSet={beatmapSet} />
 
-                <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
+                {beatmapSet.status !== "local" && (
+                  <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
+                )}
               </div>
             )}
           </div>

--- a/src/components/game/pauseScreen.tsx
+++ b/src/components/game/pauseScreen.tsx
@@ -64,13 +64,11 @@ const PauseScreen = ({
               </div>
             </div>
 
-            {beatmapSet && (
-              <div className="flex gap-2" data-exclude>
+            {beatmapSet && beatmapSet.id > 0 && (
+              <div className="absolute top-4 right-4 flex gap-2">
                 <CollectionsDropdown beatmapSet={beatmapSet} />
 
-                {beatmapSet.status !== "local" && (
-                  <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
-                )}
+                <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
               </div>
             )}
           </div>

--- a/src/components/game/results.tsx
+++ b/src/components/game/results.tsx
@@ -93,8 +93,8 @@ const Results = ({
             </div>
 
             {beatmapSet && beatmapSet.id > 0 && (
-              <div className="absolute top-4 right-4 flex gap-2">
-                <CollectionsDropdown beatmapSet={beatmapSet} />
+              <div className="flex gap-2" data-exclude>
+                <CollectionsDropdown beatmapSet={beatmapSet} alwaysShow />
 
                 <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
               </div>

--- a/src/components/game/results.tsx
+++ b/src/components/game/results.tsx
@@ -92,13 +92,11 @@ const Results = ({
               </div>
             </div>
 
-            {beatmapSet && (
-              <div className="flex gap-2" data-exclude>
-                <CollectionsDropdown beatmapSet={beatmapSet} alwaysShow />
+            {beatmapSet && beatmapSet.id > 0 && (
+              <div className="absolute top-4 right-4 flex gap-2">
+                <CollectionsDropdown beatmapSet={beatmapSet} />
 
-                {beatmapSet.status !== "local" && (
-                  <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
-                )}
+                <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
               </div>
             )}
           </div>

--- a/src/components/game/results.tsx
+++ b/src/components/game/results.tsx
@@ -96,7 +96,9 @@ const Results = ({
               <div className="flex gap-2" data-exclude>
                 <CollectionsDropdown beatmapSet={beatmapSet} alwaysShow />
 
-                <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
+                {beatmapSet.status !== "local" && (
+                  <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
+                )}
               </div>
             )}
           </div>
@@ -106,6 +108,11 @@ const Results = ({
               <p className="text-yellow-400">
                 {beatmap?.difficulty_rating.toFixed(2)}★
               </p>
+              {beatmapSet?.status === "local" && (
+                <span className="rounded bg-slate-500/20 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-cyan-300">
+                  LOCAL
+                </span>
+              )}
               <p className="line-clamp-1">{beatmapData.metadata.version}</p>
             </div>
 

--- a/src/components/game/resultsScreen.tsx
+++ b/src/components/game/resultsScreen.tsx
@@ -34,6 +34,7 @@ const ResultsScreen = ({
   const beatmapSet = useGameStore.use.beatmapSet();
   const beatmapId = useGameStore.use.beatmapId();
   const setReplayData = useGameStore.use.setReplayData();
+  const uploadedBeatmapSet = useGameStore.use.uploadedBeatmapSet();
   const mods = useSettingsStore.use.mods();
   const setHighScores = useHighScoresStore.use.setHighScores();
   const [highScorePosition, setHighScorePosition] = useState<number | null>(
@@ -46,6 +47,7 @@ const ResultsScreen = ({
     if (
       !beatmapId ||
       !beatmapSet ||
+      !!uploadedBeatmapSet ||
       mods.autoplay ||
       playResults.failed ||
       playResults.viewingReplay
@@ -105,6 +107,7 @@ const ResultsScreen = ({
   }, [
     beatmapId,
     beatmapSet,
+    uploadedBeatmapSet,
     playResults,
     setHighScores,
     mods,

--- a/src/components/replayUpload.tsx
+++ b/src/components/replayUpload.tsx
@@ -1,15 +1,38 @@
 import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import type { ReplayData } from "@/osuMania/systems/replayRecorder";
 import { decompressSync } from "fflate";
 import { Upload } from "lucide-react";
 import type { ChangeEvent, DragEvent } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { useGameStore } from "../stores/gameStore";
 
 const ReplayUpload = () => {
   const startReplay = useGameStore.use.startReplay();
+  const startLocalReplayWithBeatmap =
+    useGameStore.use.startLocalReplayWithBeatmap();
   const [isDraggingOver, setIsDraggingOver] = useState(false);
+  const [pendingLocalReplay, setPendingLocalReplay] =
+    useState<ReplayData | null>(null);
+  const [pendingLocalBeatmapFile, setPendingLocalBeatmapFile] =
+    useState<File | null>(null);
+  const [isLocalReplayDialogOpen, setIsLocalReplayDialogOpen] = useState(false);
+  const [isMismatchDialogOpen, setIsMismatchDialogOpen] = useState(false);
+  const verifyInputRef = useRef<HTMLInputElement>(null);
+
+  const isLocalReplay = (replayData: ReplayData) => {
+    const hasOnlineIds =
+      replayData.beatmap.id != null && replayData.beatmap.setId != null;
+
+    return !hasOnlineIds && !!replayData.beatmap.hash;
+  };
 
   const loadFile = (file?: File) => {
     if (!file) {
@@ -33,6 +56,12 @@ const ReplayUpload = () => {
         const decompressed = decompressSync(uint8);
         const jsonStr = new TextDecoder().decode(decompressed);
         const parsedData: ReplayData = JSON.parse(jsonStr);
+
+        if (isLocalReplay(parsedData)) {
+          setPendingLocalReplay(parsedData);
+          setIsLocalReplayDialogOpen(true);
+          return;
+        }
 
         startReplay(parsedData);
       } catch (err) {
@@ -68,42 +97,168 @@ const ReplayUpload = () => {
     loadFile(file);
   };
 
+  const handleMapVerification = async (file?: File) => {
+    if (!file || !pendingLocalReplay) {
+      return;
+    }
+
+    if (!file.name.endsWith(".osz")) {
+      toast.message("Failed to verify beatmap", {
+        description: "Please upload the original .osz beatmap file.",
+      });
+      return;
+    }
+
+    const result = await startLocalReplayWithBeatmap(pendingLocalReplay, file);
+    if (result === "started") {
+      setPendingLocalReplay(null);
+      setPendingLocalBeatmapFile(null);
+      setIsLocalReplayDialogOpen(false);
+      setIsMismatchDialogOpen(false);
+      return;
+    }
+
+    if (result === "mismatch") {
+      setPendingLocalBeatmapFile(file);
+      setIsMismatchDialogOpen(true);
+    }
+  };
+
+  const confirmMismatchPlayback = async () => {
+    if (!pendingLocalReplay || !pendingLocalBeatmapFile) {
+      return;
+    }
+
+    const result = await startLocalReplayWithBeatmap(
+      pendingLocalReplay,
+      pendingLocalBeatmapFile,
+      true,
+    );
+
+    if (result === "started") {
+      setPendingLocalReplay(null);
+      setPendingLocalBeatmapFile(null);
+      setIsLocalReplayDialogOpen(false);
+      setIsMismatchDialogOpen(false);
+    }
+  };
+
   return (
-    <div
-      className="flex w-full items-center"
-      onDragOver={(e) => {
-        e.preventDefault();
-        setIsDraggingOver(true);
-      }}
-      onDragLeave={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-          setIsDraggingOver(false);
-        }
-      }}
-      onDrop={handleDrop}
-    >
-      <label
-        htmlFor="ReplayUpload"
-        className={cn(
-          "hover:bg-accent flex w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-4 transition-colors",
-          isDraggingOver && "bg-accent",
-        )}
+    <>
+      <div
+        className="flex w-full items-center"
+        onDragOver={(e) => {
+          e.preventDefault();
+          setIsDraggingOver(true);
+        }}
+        onDragLeave={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+            setIsDraggingOver(false);
+          }
+        }}
+        onDrop={handleDrop}
       >
-        <div className="flex items-center justify-center gap-3 text-sm text-gray-500">
-          <Upload />
-          <p>
-            <span className="font-semibold">Click</span> or drag and drop
-          </p>
-        </div>
-        <input
-          id="ReplayUpload"
-          type="file"
-          accept=".womr"
-          className="hidden"
-          onChange={handleChange}
-        />
-      </label>
-    </div>
+        <label
+          htmlFor="ReplayUpload"
+          className={cn(
+            "hover:bg-accent flex w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-4 transition-colors",
+            isDraggingOver && "bg-accent",
+          )}
+        >
+          <div className="flex items-center justify-center gap-3 text-sm text-gray-500">
+            <Upload />
+            <p>
+              <span className="font-semibold">Click</span> or drag and drop
+            </p>
+          </div>
+          <input
+            id="ReplayUpload"
+            type="file"
+            accept=".womr"
+            className="hidden"
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+
+      <Dialog
+        open={isLocalReplayDialogOpen}
+        onOpenChange={(open) => {
+          setIsLocalReplayDialogOpen(open);
+          if (!open) {
+            setPendingLocalReplay(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Local Replay Detected</DialogTitle>
+            <DialogDescription>
+              This replay was made with a local beatmap. Upload the original
+              .osz file to verify the beatmap before playback.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div>
+            <input
+              ref={verifyInputRef}
+              type="file"
+              accept=".osz"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                e.target.value = "";
+                handleMapVerification(file);
+              }}
+            />
+            <label
+              className="hover:bg-accent flex cursor-pointer items-center justify-center gap-2 rounded-lg border-2 border-dashed p-4 text-sm"
+              onClick={() => verifyInputRef.current?.click()}
+            >
+              <Upload className="size-4" />
+              Upload .osz to verify
+            </label>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={isMismatchDialogOpen}
+        onOpenChange={(open) => {
+          setIsMismatchDialogOpen(open);
+          if (!open) {
+            setPendingLocalBeatmapFile(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Beatmap Mismatch</DialogTitle>
+            <DialogDescription>
+              The replay beatmap hash does not match the uploaded map. Playback
+              may be inconsistent. Continue anyway?
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              className="hover:bg-accent rounded-md border px-4 py-2 text-sm"
+              onClick={() => setIsMismatchDialogOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm"
+              onClick={confirmMismatchPlayback}
+            >
+              Okay
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/src/components/replayUpload.tsx
+++ b/src/components/replayUpload.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -6,6 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
 import type { ReplayData } from "@/osuMania/systems/replayRecorder";
 import { decompressSync } from "fflate";
 import { Upload } from "lucide-react";
@@ -28,10 +28,7 @@ const ReplayUpload = () => {
   const verifyInputRef = useRef<HTMLInputElement>(null);
 
   const isLocalReplay = (replayData: ReplayData) => {
-    const hasOnlineIds =
-      replayData.beatmap.id != null && replayData.beatmap.setId != null;
-
-    return !hasOnlineIds && !!replayData.beatmap.hash;
+    return !("setId" in replayData.beatmap);
   };
 
   const loadFile = (file?: File) => {

--- a/src/components/settings/uploadDialog.tsx
+++ b/src/components/settings/uploadDialog.tsx
@@ -34,14 +34,15 @@ const UploadDialog = () => {
       return;
     }
 
-    const audio = beatmapSet.previewUrl
-      ? playAudioPreviewFromUrl(beatmapSet.previewUrl, musicVolume)
-      : beatmapSet.id > 0
-        ? playAudioPreview(beatmapSet.id, musicVolume)
-        : null;
+    let audio: Howl | null = null;
+    if (beatmapSet.previewUrl) {
+      audio = playAudioPreviewFromUrl(beatmapSet.previewUrl, musicVolume);
+    } else if (beatmapSet.id > 0) {
+      audio = playAudioPreview(beatmapSet.id, musicVolume);
+    }
 
     if (audio) {
-      /* eslint-disable-next-line */
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPreview(audio);
     }
   }, [beatmapSet, musicVolume, replayData, uploadedBeatmapSet]);

--- a/src/components/settings/uploadDialog.tsx
+++ b/src/components/settings/uploadDialog.tsx
@@ -1,5 +1,9 @@
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { playAudioPreview, stopAudioPreview } from "@/lib/audio";
+import {
+  playAudioPreview,
+  playAudioPreviewFromUrl,
+  stopAudioPreview,
+} from "@/lib/audio";
 import { Loader } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useGameStore } from "../../stores/gameStore";
@@ -7,13 +11,13 @@ import { useSettingsStore } from "../../stores/settingsStore";
 import BeatmapList from "../beatmapSet/beatmapList";
 import BeatmapSetPageButton from "../beatmapSet/beatmapPageButton";
 import BeatmapSetCover from "../beatmapSet/beatmapSetCover";
-import CollectionsDropdown from "../beatmapSet/collectionsDropdown";
 import PreviewProgressBar from "../beatmapSet/previewProgressBar";
 
 const UploadDialog = () => {
   const uploadedBeatmapSet = useGameStore.use.uploadedBeatmapSet();
   const beatmapSet = useGameStore.use.beatmapSet();
   const beatmapId = useGameStore.use.beatmapId();
+  const replayData = useGameStore.use.replayData();
   const setUploadedBeatmapSet = useGameStore.use.setUploadedBeatmapSet();
   const musicVolume = useSettingsStore.use.musicVolume();
   const [preview, setPreview] = useState<Howl | null>(null);
@@ -26,17 +30,26 @@ const UploadDialog = () => {
   };
 
   useEffect(() => {
-    if (uploadedBeatmapSet && beatmapSet) {
-      const audio = playAudioPreview(beatmapSet.id, musicVolume);
+    if (!uploadedBeatmapSet || !beatmapSet || replayData) {
+      return;
+    }
+
+    const audio = beatmapSet.previewUrl
+      ? playAudioPreviewFromUrl(beatmapSet.previewUrl, musicVolume)
+      : beatmapSet.id > 0
+        ? playAudioPreview(beatmapSet.id, musicVolume)
+        : null;
+
+    if (audio) {
       /* eslint-disable-next-line */
       setPreview(audio);
     }
-  }, [beatmapSet, musicVolume, uploadedBeatmapSet]);
+  }, [beatmapSet, musicVolume, replayData, uploadedBeatmapSet]);
 
   return (
     <>
       <Dialog
-        open={!!uploadedBeatmapSet && !beatmapId}
+        open={!!uploadedBeatmapSet && !beatmapId && !replayData}
         onOpenChange={(open) => {
           if (!open) {
             stopPreview();
@@ -49,7 +62,7 @@ const UploadDialog = () => {
           aria-describedby={undefined}
         >
           <DialogTitle className="sr-only">Beatmap Set Upload</DialogTitle>
-          {uploadedBeatmapSet && !beatmapSet && (
+          {uploadedBeatmapSet && !beatmapSet && !replayData && (
             <div className="p-4">
               <h3 className="text-center text-2xl font-medium">
                 Getting Beatmap Information...
@@ -57,7 +70,7 @@ const UploadDialog = () => {
               <Loader className="mx-auto mt-4 animate-spin" />
             </div>
           )}
-          {uploadedBeatmapSet && beatmapSet && (
+          {uploadedBeatmapSet && beatmapSet && !replayData && (
             <>
               <div className="group relative flex h-37.5 flex-col p-4 text-start">
                 <BeatmapSetCover beatmapSet={beatmapSet} />
@@ -69,9 +82,9 @@ const UploadDialog = () => {
                 )}
 
                 <div className="absolute top-4 right-4 flex gap-2">
-                  <CollectionsDropdown beatmapSet={beatmapSet} />
-
-                  <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
+                  {beatmapSet.status !== "local" && (
+                    <BeatmapSetPageButton beatmapSetId={beatmapSet.id} />
+                  )}
                 </div>
               </div>
 

--- a/src/components/settings/uploadDialog.tsx
+++ b/src/components/settings/uploadDialog.tsx
@@ -55,6 +55,16 @@ const UploadDialog = () => {
           if (!open) {
             stopPreview();
             setUploadedBeatmapSet(null);
+
+            if (beatmapSet) {
+              if (beatmapSet.coverUrl) {
+                URL.revokeObjectURL(beatmapSet.coverUrl);
+              }
+
+              if (beatmapSet.previewUrl) {
+                URL.revokeObjectURL(beatmapSet.previewUrl);
+              }
+            }
           }
         }}
       >

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -87,6 +87,58 @@ export function playAudioPreview(beatmapSetId: number, volume: number) {
   return audio;
 }
 
+export function playAudioPreviewFromUrl(audioUrl: string, volume: number) {
+  const audio = new Howl({
+    src: [audioUrl],
+    format: "wav",
+    html5: true,
+    autoplay: true,
+    volume: 0,
+    onplay: () => {
+      audio.fade(0, volume, 500);
+    },
+    onloaderror: () => {
+      toast.message("Audio preview could not be loaded.");
+    },
+  });
+
+  return audio;
+}
+
+export async function createAudioPreviewClip(
+  blob: Blob,
+  startTime: number,
+  duration = 10,
+) {
+  const audioCtx = new AudioContext();
+  const blobArrayBuffer = await blob.arrayBuffer();
+  const audioBuffer = await audioCtx.decodeAudioData(blobArrayBuffer);
+
+  const safeStartTime = Math.max(0, startTime);
+  const maxDuration = Math.max(audioBuffer.duration - safeStartTime, 0);
+  const clipDuration = Math.max(Math.min(duration, maxDuration), 0.1);
+
+  const totalLength = Math.ceil(clipDuration * audioBuffer.sampleRate);
+
+  const offlineCtx = new OfflineAudioContext(
+    audioBuffer.numberOfChannels,
+    totalLength,
+    audioBuffer.sampleRate,
+  );
+
+  const source = new AudioBufferSourceNode(offlineCtx, {
+    buffer: audioBuffer,
+  });
+
+  source.connect(offlineCtx.destination);
+  source.start(0, safeStartTime, clipDuration);
+
+  const renderedBuffer = await offlineCtx.startRendering();
+  const wav = toWav(renderedBuffer);
+
+  return new Blob([wav], { type: "audio/wav" });
+}
+
 export function stopAudioPreview(audio: Howl) {
   audio.fade(audio.volume(), 0, 500);
 

--- a/src/lib/beatmapParser.ts
+++ b/src/lib/beatmapParser.ts
@@ -3,8 +3,9 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import type { Entry, FileEntry } from "@zip.js/zip.js";
 import { BlobReader, BlobWriter, TextWriter, ZipReader } from "@zip.js/zip.js";
 import { Howl } from "howler";
-import { addDelay } from "./audio";
-import type { Beatmap } from "./osuApi";
+import { addDelay, createAudioPreviewClip } from "./audio";
+import { calculateManiaStarRating } from "./maniaDifficulty";
+import type { Beatmap, BeatmapSet } from "./osuApi";
 import type { EncodedMods } from "./replay";
 import { decodeMods } from "./replay";
 import { getHpOrOdAfterMods, removeFileExtension, shuffle } from "./utils";
@@ -100,6 +101,8 @@ export type HitWindows = {
 export interface BeatmapData {
   beatmapId: number;
   beatmapSetId: number;
+  beatmapHash: string;
+  isLocalSource: boolean;
   version: string;
   timingPoints: TimingPoint[];
   hitObjects: HitObject[];
@@ -122,6 +125,7 @@ export const parseOsz = async (
   beatmap: Beatmap,
   replayMods?: EncodedMods,
   replayColumnMap?: number[],
+  isLocalSource = false,
 ): Promise<BeatmapData> => {
   const zipReader = new ZipReader(new BlobReader(blob));
   const entries = await zipReader.getEntries();
@@ -151,6 +155,8 @@ export const parseOsz = async (
   if (!osuFileData) {
     throw new Error(".osu file not found");
   }
+
+  const beatmapHash = await getStringSha256Hex(osuFileData);
 
   const lines = osuFileData?.split(/\r\n|\n\r|\n/);
 
@@ -281,6 +287,8 @@ export const parseOsz = async (
   return {
     beatmapSetId: beatmap.beatmapset_id,
     beatmapId: beatmap.id,
+    beatmapHash,
+    isLocalSource,
     version: beatmap.version,
     timingPoints,
     hitObjects,
@@ -300,12 +308,16 @@ export const parseOsz = async (
 };
 
 function findEntry(entries: Entry[], filename: string) {
-  const lowercaseFilename = filename.toLowerCase();
+  const lowercaseFilename = normalizeArchivePath(filename);
   return entries.find(
     (entry) =>
       entry.filename.toLowerCase().endsWith(lowercaseFilename) &&
       !entry.directory,
   ) as FileEntry;
+}
+
+function normalizeArchivePath(path: string) {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").trim().toLowerCase();
 }
 
 export function parseHitObjects(
@@ -475,10 +487,9 @@ async function parseEvents(
     if (videoLine) {
       const [_, startTime, filename, xOffset, yOffset] = videoLine.split(",");
 
-      // Remove quotes
-      const parsedFilename = filename.slice(1, -1);
+      const parsedFilename = filename.trim().replace(/^"|"$/g, "");
 
-      if (parsedFilename.endsWith(".mp4")) {
+      if (parsedFilename.toLowerCase().endsWith(".mp4")) {
         const videoEntry = findEntry(entries, parsedFilename);
 
         if (videoEntry) {
@@ -673,4 +684,213 @@ export async function getBeatmapSetIdFromOsz(blob: Blob) {
   const beatmapSetId = getLineValue(lines, "BeatmapSetID");
 
   return beatmapSetId;
+}
+
+export async function getBeatmapSetFromOsz(blob: Blob): Promise<BeatmapSet> {
+  const zipReader = new ZipReader(new BlobReader(blob));
+  const entries = await zipReader.getEntries();
+
+  const osuEntries = entries.filter(
+    (entry) => entry.filename.endsWith(".osu") && !entry.directory,
+  ) as FileEntry[];
+
+  if (osuEntries.length === 0) {
+    throw new Error("No .osu files found.");
+  }
+
+  const beatmaps: Beatmap[] = [];
+  let coverUrl: string | undefined;
+  let previewUrl: string | undefined;
+
+  const firstOsuText = await osuEntries[0].getData(new TextWriter());
+  const firstOsuLines = firstOsuText.split(/\r\n|\n\r|\n/);
+  const coverFilename = firstOsuLines
+    .find((line) => line.startsWith("0,0,"))
+    ?.split(",")[2]
+    ?.replaceAll('"', "");
+
+  if (coverFilename) {
+    const coverEntry = findEntry(entries, coverFilename);
+    if (coverEntry) {
+      const coverBlob = await coverEntry.getData(new BlobWriter());
+      coverUrl = URL.createObjectURL(coverBlob);
+    }
+  }
+
+  const previewTimeMs = Number(
+    getLineValueOrDefault(firstOsuLines, "PreviewTime", "0"),
+  );
+  const previewStartTime = previewTimeMs > 0 ? previewTimeMs / 1000 : 0;
+
+  const songFilename = getLineValueOrDefault(
+    firstOsuLines,
+    "AudioFilename",
+    "",
+  );
+  if (songFilename) {
+    const songEntry = findEntry(entries, songFilename);
+    if (songEntry) {
+      const songBlob = await songEntry.getData(new BlobWriter());
+      const previewBlob = await createAudioPreviewClip(
+        songBlob,
+        previewStartTime,
+        10,
+      );
+      previewUrl = URL.createObjectURL(previewBlob);
+    }
+  }
+  let setMetadata:
+    | {
+        artist: string;
+        artistUnicode: string;
+        title: string;
+        titleUnicode: string;
+        creator: string;
+        beatmapSetId: number;
+      }
+    | undefined;
+
+  for (let i = 0; i < osuEntries.length; i++) {
+    const text = await osuEntries[i].getData(new TextWriter());
+    const lines = text.split(/\r\n|\n\r|\n/);
+
+    const mode = Number(getLineValueOrDefault(lines, "Mode", "0"));
+    if (mode !== 3) {
+      continue;
+    }
+
+    const metadata = parseMetadata(lines);
+    const difficulty = parseDifficulty(lines);
+    const hitObjectsSection = getSectionLines(lines, "HitObjects");
+    const starRating = calculateManiaStarRating(lines);
+
+    if (hitObjectsSection.length === 0) {
+      continue;
+    }
+
+    const beatmapId = Number(getLineValueOrDefault(lines, "BeatmapID", "0"));
+    const beatmapSetId = Number(
+      getLineValueOrDefault(lines, "BeatmapSetID", "0"),
+    );
+    const beatmapHash = await getStringSha256Hex(text);
+
+    if (!setMetadata) {
+      setMetadata = {
+        artist: metadata.artist,
+        artistUnicode: metadata.artistUnicode,
+        title: metadata.title,
+        titleUnicode: metadata.titleUnicode,
+        creator: metadata.creator,
+        beatmapSetId,
+      };
+    }
+
+    const totalLengthSeconds = Math.ceil(
+      getBeatmapDurationMs(hitObjectsSection) / 1000,
+    );
+
+    beatmaps.push({
+      beatmapset_id: beatmapSetId,
+      difficulty_rating: starRating,
+      id: beatmapId > 0 ? beatmapId : -(i + 1),
+      hash: beatmapHash,
+      mode: "mania",
+      total_length: totalLengthSeconds,
+      user_id: 0,
+      version: metadata.version,
+      bpm: 0,
+      cs: difficulty.keyCount,
+      accuracy: difficulty.od,
+      drain: difficulty.hp,
+      count_circles: hitObjectsSection.filter((line) => {
+        const type = Number(line.split(",")[3]);
+        return type !== 128;
+      }).length,
+      count_sliders: hitObjectsSection.filter((line) => {
+        const type = Number(line.split(",")[3]);
+        return type === 128;
+      }).length,
+    });
+  }
+
+  if (beatmaps.length === 0) {
+    throw new Error("No osu!mania difficulties found in this .osz file.");
+  }
+
+  const fallbackId = -Date.now();
+
+  return {
+    artist: setMetadata?.artist ?? "",
+    artist_unicode: setMetadata?.artistUnicode ?? "",
+    creator: setMetadata?.creator ?? "",
+    id:
+      setMetadata && setMetadata.beatmapSetId > 0
+        ? setMetadata.beatmapSetId
+        : fallbackId,
+    nsfw: false,
+    offset: 0,
+    status: "local",
+    title: setMetadata?.title ?? "",
+    title_unicode: setMetadata?.titleUnicode ?? "",
+    coverUrl,
+    previewUrl,
+    beatmaps,
+  };
+}
+
+function getSectionLines(lines: string[], sectionName: string) {
+  const startIndex = lines.indexOf(`[${sectionName}]`) + 1;
+  const endIndex = lines.findIndex((line, i) => line === "" && i > startIndex);
+
+  return lines.slice(startIndex, endIndex).filter(Boolean);
+}
+
+function getLineValueOrDefault(
+  lines: string[],
+  key: string,
+  defaultValue: string,
+) {
+  const line = lines.find((l) => l.startsWith(`${key}:`));
+
+  if (!line) {
+    return defaultValue;
+  }
+
+  return line.split(`${key}:`)[1].trim();
+}
+
+async function getStringSha256Hex(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", bytes);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function getBeatmapDurationMs(hitObjectLines: string[]) {
+  let maxTime = 0;
+
+  for (const line of hitObjectLines) {
+    const parts = line.split(",");
+    if (parts.length < 4) {
+      continue;
+    }
+
+    const startTime = Number(parts[2]);
+    const type = Number(parts[3]);
+
+    let endTime = startTime;
+    if (type === 128 && parts.length > 5) {
+      const holdEndTime = Number(parts[5].split(":")[0]);
+      if (Number.isFinite(holdEndTime)) {
+        endTime = holdEndTime;
+      }
+    }
+
+    if (endTime > maxTime) {
+      maxTime = endTime;
+    }
+  }
+
+  return maxTime;
 }

--- a/src/lib/beatmapParser.ts
+++ b/src/lib/beatmapParser.ts
@@ -762,6 +762,7 @@ export async function getBeatmapSetFromOsz(blob: Blob): Promise<BeatmapSet> {
     const metadata = parseMetadata(lines);
     const difficulty = parseDifficulty(lines);
     const hitObjectsSection = getSectionLines(lines, "HitObjects");
+    const highestBpm = getHighestBpm(lines);
     const starRating = calculateManiaStarRating(lines);
 
     if (hitObjectsSection.length === 0) {
@@ -798,7 +799,7 @@ export async function getBeatmapSetFromOsz(blob: Blob): Promise<BeatmapSet> {
       total_length: totalLengthSeconds,
       user_id: 0,
       version: metadata.version,
-      bpm: 0,
+      bpm: highestBpm,
       cs: difficulty.keyCount,
       accuracy: difficulty.od,
       drain: difficulty.hp,
@@ -893,4 +894,30 @@ function getBeatmapDurationMs(hitObjectLines: string[]) {
   }
 
   return maxTime;
+}
+
+function getHighestBpm(lines: string[]) {
+  const timingPointLines = getSectionLines(lines, "TimingPoints");
+  let highestBpm = 0;
+
+  for (const line of timingPointLines) {
+    const parts = line.split(",");
+    if (parts.length < 2) {
+      continue;
+    }
+
+    const msPerBeat = Number(parts[1]);
+
+    // Uninherited timing points only
+    if (!Number.isFinite(msPerBeat) || msPerBeat <= 0) {
+      continue;
+    }
+
+    const bpm = 60000 / msPerBeat;
+    if (bpm > highestBpm) {
+      highestBpm = bpm;
+    }
+  }
+
+  return Math.round(highestBpm);
 }

--- a/src/lib/beatmapParser.ts
+++ b/src/lib/beatmapParser.ts
@@ -329,12 +329,9 @@ export function parseHitObjects(
   audioOffset: number,
   replayColumnMap?: number[],
 ) {
-  const startIndex = lines.indexOf("[HitObjects]") + 1;
-  const endIndex = lines.findIndex((line, i) => line === "" && i > startIndex);
-
   // https://osu.ppy.sh/wiki/en/Client/File_formats/osu_%28file_format%29#holds-(osu!mania-only)
   const hitObjects: HitObject[] = [];
-  const hitObjectData = lines.slice(startIndex, endIndex);
+  const hitObjectData = getSectionLines(lines, "HitObjects");
 
   // Hit objects may be empty when downloading from SayoBot
   if (hitObjectData.length === 0) {
@@ -473,10 +470,7 @@ async function parseEvents(
   entries: Entry[],
   delay: number,
 ): Promise<Events> {
-  const startIndex = lines.indexOf("[Events]") + 1;
-  const endIndex = lines.findIndex((line, i) => line === "" && i > startIndex);
-
-  const eventLines = lines.slice(startIndex, endIndex);
+  const eventLines = getSectionLines(lines, "Events");
 
   // Parse video
   let videoUrl: string | null = null;
@@ -531,10 +525,7 @@ function parseTimingPoints(
   mods: Settings["mods"],
   audioOffset: number,
 ): TimingPoint[] {
-  const startIndex = lines.indexOf("[TimingPoints]") + 1;
-  const endIndex = lines.findIndex((line, i) => line === "" && i > startIndex);
-
-  const timingPointLines = lines.slice(startIndex, endIndex);
+  const timingPointLines = getSectionLines(lines, "TimingPoints");
 
   const settings = useSettingsStore.getState();
   const baseScrollSpeed = settings.scrollSpeed;
@@ -652,6 +643,20 @@ function getLineValue(lines: string[], key: string) {
   return value;
 }
 
+function getLineValueOrDefault(
+  lines: string[],
+  key: string,
+  defaultValue: string,
+) {
+  const line = lines.find((l) => l.startsWith(`${key}:`));
+
+  if (!line) {
+    return defaultValue;
+  }
+
+  return line.split(`${key}:`)[1].trim();
+}
+
 // https://osu.ppy.sh/wiki/en/Gameplay/Judgement/osu%21mania#scorev2
 // Table: https://i.ppy.sh/d0319d39fbc14fb6e380264e78d1e2c839c6912c/68747470733a2f2f646c2e64726f70626f7875736572636f6e74656e742e636f6d2f732f6d757837616176393779386c7639302f6f73756d616e69612532424f442e706e67
 function getHitWindows(od: number, mods: Settings["mods"]): HitWindows {
@@ -713,6 +718,7 @@ export async function getBeatmapSetFromOsz(blob: Blob): Promise<BeatmapSet> {
 
   if (coverFilename) {
     const coverEntry = findEntry(entries, coverFilename);
+
     if (coverEntry) {
       const coverBlob = await coverEntry.getData(new BlobWriter());
       coverUrl = URL.createObjectURL(coverBlob);
@@ -741,15 +747,11 @@ export async function getBeatmapSetFromOsz(blob: Blob): Promise<BeatmapSet> {
       previewUrl = URL.createObjectURL(previewBlob);
     }
   }
-  let setMetadata:
-    | {
-        artist: string;
-        artistUnicode: string;
-        title: string;
-        titleUnicode: string;
-        creator: string;
+
+  let beatmapSetMetadata:
+    | (Metadata & {
         beatmapSetId: number;
-      }
+      })
     | undefined;
 
   for (let i = 0; i < osuEntries.length; i++) {
@@ -777,13 +779,9 @@ export async function getBeatmapSetFromOsz(blob: Blob): Promise<BeatmapSet> {
     );
     const beatmapHash = await getStringSha256Hex(text);
 
-    if (!setMetadata) {
-      setMetadata = {
-        artist: metadata.artist,
-        artistUnicode: metadata.artistUnicode,
-        title: metadata.title,
-        titleUnicode: metadata.titleUnicode,
-        creator: metadata.creator,
+    if (!beatmapSetMetadata) {
+      beatmapSetMetadata = {
+        ...metadata,
         beatmapSetId,
       };
     }
@@ -820,46 +818,32 @@ export async function getBeatmapSetFromOsz(blob: Blob): Promise<BeatmapSet> {
     throw new Error("No osu!mania difficulties found in this .osz file.");
   }
 
-  const fallbackId = -Date.now();
+  const fallbackId = 0;
 
   return {
-    artist: setMetadata?.artist ?? "",
-    artist_unicode: setMetadata?.artistUnicode ?? "",
-    creator: setMetadata?.creator ?? "",
+    artist: beatmapSetMetadata?.artist ?? "",
+    artist_unicode: beatmapSetMetadata?.artistUnicode ?? "",
+    creator: beatmapSetMetadata?.creator ?? "",
     id:
-      setMetadata && setMetadata.beatmapSetId > 0
-        ? setMetadata.beatmapSetId
+      beatmapSetMetadata && beatmapSetMetadata.beatmapSetId > 0
+        ? beatmapSetMetadata.beatmapSetId
         : fallbackId,
     nsfw: false,
     offset: 0,
     status: "local",
-    title: setMetadata?.title ?? "",
-    title_unicode: setMetadata?.titleUnicode ?? "",
+    title: beatmapSetMetadata?.title ?? "",
+    title_unicode: beatmapSetMetadata?.titleUnicode ?? "",
     coverUrl,
     previewUrl,
     beatmaps,
   };
 }
 
-function getSectionLines(lines: string[], sectionName: string) {
+export function getSectionLines(lines: string[], sectionName: string) {
   const startIndex = lines.indexOf(`[${sectionName}]`) + 1;
   const endIndex = lines.findIndex((line, i) => line === "" && i > startIndex);
 
   return lines.slice(startIndex, endIndex).filter(Boolean);
-}
-
-function getLineValueOrDefault(
-  lines: string[],
-  key: string,
-  defaultValue: string,
-) {
-  const line = lines.find((l) => l.startsWith(`${key}:`));
-
-  if (!line) {
-    return defaultValue;
-  }
-
-  return line.split(`${key}:`)[1].trim();
 }
 
 async function getStringSha256Hex(text: string): Promise<string> {

--- a/src/lib/idb.ts
+++ b/src/lib/idb.ts
@@ -1,4 +1,5 @@
 import type { ReplayData } from "@/osuMania/systems/replayRecorder";
+import { normalizeReplayBeatmapReference } from "./replay";
 import { compressSync } from "fflate";
 import type { DBSchema, IDBPDatabase } from "idb";
 import { openDB } from "idb";
@@ -157,7 +158,8 @@ class Idb {
   public async saveReplay(replayData: ReplayData, id: string): Promise<string> {
     const db = await this.db;
 
-    const replayDataString = JSON.stringify(replayData);
+    const normalizedReplay = normalizeReplayBeatmapReference(replayData);
+    const replayDataString = JSON.stringify(normalizedReplay);
     const encoded = new TextEncoder().encode(replayDataString);
     const compressed = compressSync(encoded);
     const file = new Blob([compressed as BlobPart], {

--- a/src/lib/idb.ts
+++ b/src/lib/idb.ts
@@ -1,5 +1,4 @@
 import type { ReplayData } from "@/osuMania/systems/replayRecorder";
-import { normalizeReplayBeatmapReference } from "./replay";
 import { compressSync } from "fflate";
 import type { DBSchema, IDBPDatabase } from "idb";
 import { openDB } from "idb";
@@ -158,8 +157,7 @@ class Idb {
   public async saveReplay(replayData: ReplayData, id: string): Promise<string> {
     const db = await this.db;
 
-    const normalizedReplay = normalizeReplayBeatmapReference(replayData);
-    const replayDataString = JSON.stringify(normalizedReplay);
+    const replayDataString = JSON.stringify(replayData);
     const encoded = new TextEncoder().encode(replayDataString);
     const compressed = compressSync(encoded);
     const file = new Blob([compressed as BlobPart], {

--- a/src/lib/maniaDifficulty.ts
+++ b/src/lib/maniaDifficulty.ts
@@ -1,0 +1,353 @@
+type ManiaHitObject = {
+  startTime: number;
+  endTime: number;
+  column: number;
+};
+
+type ManiaDifficultyHitObject = {
+  index: number;
+  startTime: number;
+  endTime: number;
+  deltaTime: number;
+  column: number;
+  columnStrainTime: number;
+  previousHitObjects: (ManiaDifficultyHitObject | null)[];
+  previous: (backwardsIndex: number) => ManiaDifficultyHitObject | null;
+};
+
+const DIFFICULTY_MULTIPLIER = 0.018;
+const INDIVIDUAL_DECAY_BASE = 0.125;
+const OVERALL_DECAY_BASE = 0.3;
+const DECAY_WEIGHT = 0.9;
+const SECTION_LENGTH = 400;
+const RELEASE_THRESHOLD = 30;
+
+export function calculateManiaStarRating(lines: string[]): number {
+  const totalColumns = Number(getLineValueOrDefault(lines, "CircleSize", "4"));
+  const hitObjects = parseManiaHitObjects(lines, totalColumns);
+
+  if (hitObjects.length < 2) {
+    return 0;
+  }
+
+  const difficultyObjects = createDifficultyHitObjects(
+    hitObjects,
+    totalColumns,
+  );
+  const strainDifficulty = calculateStrainDifficulty(
+    difficultyObjects,
+    totalColumns,
+  );
+
+  return strainDifficulty * DIFFICULTY_MULTIPLIER;
+}
+
+function parseManiaHitObjects(
+  lines: string[],
+  totalColumns: number,
+): ManiaHitObject[] {
+  const startIndex = lines.indexOf("[HitObjects]") + 1;
+  const endIndex = lines.findIndex((line, i) => line === "" && i > startIndex);
+  const sectionLines = lines.slice(startIndex, endIndex).filter(Boolean);
+
+  const result: ManiaHitObject[] = [];
+
+  for (const line of sectionLines) {
+    const parts = line.split(",");
+    if (parts.length < 5) {
+      continue;
+    }
+
+    const x = Number(parts[0]);
+    const startTime = Number(parts[2]);
+    const type = Number(parts[3]);
+    const column = Math.floor((x * totalColumns) / 512);
+
+    const isHold = type === 128;
+    let endTime = startTime;
+
+    if (isHold) {
+      const holdData = parts[5]?.split(":")[0];
+      const parsedEndTime = Number(holdData);
+      if (Number.isFinite(parsedEndTime)) {
+        endTime = parsedEndTime;
+      }
+    }
+
+    result.push({
+      startTime,
+      endTime,
+      column,
+    });
+  }
+
+  result.sort((a, b) => Math.round(a.startTime) - Math.round(b.startTime));
+  return result;
+}
+
+function createDifficultyHitObjects(
+  hitObjects: ManiaHitObject[],
+  totalColumns: number,
+): ManiaDifficultyHitObject[] {
+  const objects: ManiaDifficultyHitObject[] = [];
+  const perColumnObjects: ManiaDifficultyHitObject[][] = Array.from(
+    { length: totalColumns },
+    () => [],
+  );
+
+  for (let i = 1; i < hitObjects.length; i++) {
+    const current = hitObjects[i];
+    const last = hitObjects[i - 1];
+    const columnObjects = perColumnObjects[current.column];
+    const previousInColumn = columnObjects[columnObjects.length - 1] ?? null;
+
+    const previousHitObjects: (ManiaDifficultyHitObject | null)[] = new Array(
+      totalColumns,
+    ).fill(null);
+
+    if (objects.length > 0) {
+      const prev = objects[objects.length - 1];
+      for (let j = 0; j < totalColumns; j++) {
+        previousHitObjects[j] = prev.previousHitObjects[j];
+      }
+      previousHitObjects[prev.column] = prev;
+    }
+
+    const index = objects.length;
+    const difficultyObject: ManiaDifficultyHitObject = {
+      index,
+      startTime: current.startTime,
+      endTime: current.endTime,
+      deltaTime: current.startTime - last.startTime,
+      column: current.column,
+      columnStrainTime: previousInColumn
+        ? current.startTime - previousInColumn.startTime
+        : current.startTime,
+      previousHitObjects,
+      previous: (backwardsIndex: number) => {
+        const targetIndex = index - (backwardsIndex + 1);
+        return targetIndex >= 0 && targetIndex < objects.length
+          ? objects[targetIndex]
+          : null;
+      },
+    };
+
+    objects.push(difficultyObject);
+    perColumnObjects[current.column].push(difficultyObject);
+  }
+
+  return objects;
+}
+
+function calculateStrainDifficulty(
+  objects: ManiaDifficultyHitObject[],
+  totalColumns: number,
+): number {
+  const individualStrains: number[] = new Array(totalColumns).fill(0);
+  let highestIndividualStrain = 0;
+  let overallStrain = 1;
+  let currentStrain = 0;
+
+  let currentSectionPeak = 0;
+  let currentSectionEnd = 0;
+  const strainPeaks: number[] = [];
+
+  for (const current of objects) {
+    if (current.index === 0) {
+      currentSectionEnd =
+        Math.ceil(current.startTime / SECTION_LENGTH) * SECTION_LENGTH;
+    }
+
+    while (current.startTime > currentSectionEnd) {
+      strainPeaks.push(currentSectionPeak);
+
+      const previous = current.previous(0);
+      const previousStartTime = previous
+        ? previous.startTime
+        : current.startTime;
+
+      const initialIndividual = applyDecay(
+        highestIndividualStrain,
+        currentSectionEnd - previousStartTime,
+        INDIVIDUAL_DECAY_BASE,
+      );
+      const initialOverall = applyDecay(
+        overallStrain,
+        currentSectionEnd - previousStartTime,
+        OVERALL_DECAY_BASE,
+      );
+
+      currentSectionPeak = initialIndividual + initialOverall;
+      currentSectionEnd += SECTION_LENGTH;
+    }
+
+    currentStrain *= applyDecayBase(current.deltaTime, 1);
+    currentStrain += strainValueOf(
+      current,
+      individualStrains,
+      () => highestIndividualStrain,
+      (value) => {
+        highestIndividualStrain = value;
+      },
+      () => overallStrain,
+      (value) => {
+        overallStrain = value;
+      },
+      currentStrain,
+    );
+
+    currentSectionPeak = Math.max(currentStrain, currentSectionPeak);
+  }
+
+  strainPeaks.push(currentSectionPeak);
+
+  let difficulty = 0;
+  let weight = 1;
+
+  const peaks = strainPeaks.filter((peak) => peak > 0).sort((a, b) => b - a);
+  for (const peak of peaks) {
+    difficulty += peak * weight;
+    weight *= DECAY_WEIGHT;
+  }
+
+  return difficulty;
+}
+
+function strainValueOf(
+  current: ManiaDifficultyHitObject,
+  individualStrains: number[],
+  getHighestIndividualStrain: () => number,
+  setHighestIndividualStrain: (value: number) => void,
+  getOverallStrain: () => number,
+  setOverallStrain: (value: number) => void,
+  currentStrain: number,
+): number {
+  const column = current.column;
+
+  individualStrains[column] = applyDecay(
+    individualStrains[column],
+    current.columnStrainTime,
+    INDIVIDUAL_DECAY_BASE,
+  );
+  individualStrains[column] += evaluateIndividualDifficulty(current);
+
+  const highestIndividualStrain =
+    current.deltaTime <= 1
+      ? Math.max(getHighestIndividualStrain(), individualStrains[column])
+      : individualStrains[column];
+  setHighestIndividualStrain(highestIndividualStrain);
+
+  const overallStrain =
+    applyDecay(getOverallStrain(), current.deltaTime, OVERALL_DECAY_BASE) +
+    evaluateOverallDifficulty(current);
+  setOverallStrain(overallStrain);
+
+  return highestIndividualStrain + overallStrain - currentStrain;
+}
+
+function evaluateIndividualDifficulty(
+  current: ManiaDifficultyHitObject,
+): number {
+  const startTime = current.startTime;
+  const endTime = current.endTime;
+
+  let holdFactor = 1;
+
+  for (const previous of current.previousHitObjects) {
+    if (!previous) {
+      continue;
+    }
+
+    if (
+      definitelyBigger(previous.endTime, endTime, 1) &&
+      definitelyBigger(startTime, previous.startTime, 1)
+    ) {
+      holdFactor = 1.25;
+      break;
+    }
+  }
+
+  return 2 * holdFactor;
+}
+
+function evaluateOverallDifficulty(current: ManiaDifficultyHitObject): number {
+  const startTime = current.startTime;
+  const endTime = current.endTime;
+  let isOverlapping = false;
+
+  let closestEndTime = Math.abs(endTime - startTime);
+  let holdFactor = 1;
+  let holdAddition = 0;
+
+  for (const previous of current.previousHitObjects) {
+    if (!previous) {
+      continue;
+    }
+
+    isOverlapping =
+      isOverlapping ||
+      (definitelyBigger(previous.endTime, startTime, 1) &&
+        definitelyBigger(endTime, previous.endTime, 1) &&
+        definitelyBigger(startTime, previous.startTime, 1));
+
+    if (
+      definitelyBigger(previous.endTime, endTime, 1) &&
+      definitelyBigger(startTime, previous.startTime, 1)
+    ) {
+      holdFactor = 1.25;
+    }
+
+    closestEndTime = Math.min(
+      closestEndTime,
+      Math.abs(endTime - previous.endTime),
+    );
+  }
+
+  if (isOverlapping) {
+    holdAddition = logistic(closestEndTime, RELEASE_THRESHOLD, 0.27);
+  }
+
+  return (1 + holdAddition) * holdFactor;
+}
+
+function definitelyBigger(
+  a: number,
+  b: number,
+  acceptableDifference: number,
+): boolean {
+  return a - b > acceptableDifference;
+}
+
+function logistic(
+  x: number,
+  midpointOffset: number,
+  multiplier: number,
+  maxValue = 1,
+): number {
+  return maxValue / (1 + Math.exp(multiplier * (midpointOffset - x)));
+}
+
+function applyDecay(
+  value: number,
+  deltaTime: number,
+  decayBase: number,
+): number {
+  return value * Math.pow(decayBase, deltaTime / 1000);
+}
+
+function applyDecayBase(ms: number, decayBase: number): number {
+  return Math.pow(decayBase, ms / 1000);
+}
+
+function getLineValueOrDefault(
+  lines: string[],
+  key: string,
+  defaultValue: string,
+): string {
+  const line = lines.find((l) => l.startsWith(`${key}:`));
+  if (!line) {
+    return defaultValue;
+  }
+
+  return line.split(`${key}:`)[1].trim();
+}

--- a/src/lib/maniaDifficulty.ts
+++ b/src/lib/maniaDifficulty.ts
@@ -36,10 +36,9 @@
  *   https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs#L124
  * - logistic function definition:
  *   https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Utils/DifficultyCalculationUtils.cs#L41
- * 
- * Note: This was created with the help of `GPT-5.3 Codex` becasue I (Sling) have not learned C# and was having trouble fully understanding it.
  */
 
+import { getSectionLines } from "./beatmapParser";
 
 type ManiaHitObject = {
   startTime: number;
@@ -89,9 +88,7 @@ function parseManiaHitObjects(
   lines: string[],
   totalColumns: number,
 ): ManiaHitObject[] {
-  const startIndex = lines.indexOf("[HitObjects]") + 1;
-  const endIndex = lines.findIndex((line, i) => line === "" && i > startIndex);
-  const sectionLines = lines.slice(startIndex, endIndex).filter(Boolean);
+  const sectionLines = getSectionLines(lines, "HitObjects");
 
   const result: ManiaHitObject[] = [];
 

--- a/src/lib/maniaDifficulty.ts
+++ b/src/lib/maniaDifficulty.ts
@@ -1,3 +1,46 @@
+/**
+ * osu!mania star rating source references
+ *
+ * Core files:
+ * - https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+ * - https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+ * - https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Evaluators/IndividualStrainEvaluator.cs
+ * - https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Evaluators/OverallStrainEvaluator.cs
+ *
+ * Shared difficulty framework:
+ * - https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Skills/StrainDecaySkill.cs
+ * - https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+ * - https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
+ * - https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Utils/DifficultyCalculationUtils.cs
+ *
+ * Key line anchors used:
+ * - difficulty_multiplier = 0.018:
+ *   https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs#L27
+ * - star rating formula (Strain.DifficultyValue * difficulty_multiplier):
+ *   https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs#L49
+ * - individual_decay_base = 0.125:
+ *   https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs#L15
+ * - overall_decay_base = 0.30:
+ *   https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs#L16
+ * - strain processing logic:
+ *   https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs#L32
+ * - individual strain evaluator:
+ *   https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Evaluators/IndividualStrainEvaluator.cs#L12
+ * - overall strain evaluator (release_threshold, logistic usage):
+ *   https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Evaluators/OverallStrainEvaluator.cs#L14
+ *   https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/Evaluators/OverallStrainEvaluator.cs#L56
+ * - section decay weight / length (0.9 / 400ms):
+ *   https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs#L21
+ *   https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs#L26
+ * - weighted peak aggregation:
+ *   https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs#L124
+ * - logistic function definition:
+ *   https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Difficulty/Utils/DifficultyCalculationUtils.cs#L41
+ * 
+ * Note: This was created with the help of `GPT-5.3 Codex` becasue I (Sling) have not learned C# and was having trouble fully understanding it.
+ */
+
+
 type ManiaHitObject = {
   startTime: number;
   endTime: number;

--- a/src/lib/osuApi.ts
+++ b/src/lib/osuApi.ts
@@ -25,6 +25,7 @@ const STATUSES = [
   "pending",
   "graveyard",
   "wip",
+  "local",
 ] as const;
 export type Status = (typeof STATUSES)[number];
 
@@ -47,6 +48,7 @@ export type Beatmap = {
 
   count_circles: number; // Tap note count
   count_sliders: number; // Hold note count
+  hash?: string;
 };
 
 // type Covers = {
@@ -76,6 +78,8 @@ export type BeatmapSet = {
   // spotlight: boolean;
   title: string;
   title_unicode: string;
+  coverUrl?: string;
+  previewUrl?: string;
   // user_id: number;
   // video: boolean;
 

--- a/src/lib/osuApi.ts
+++ b/src/lib/osuApi.ts
@@ -25,6 +25,8 @@ const STATUSES = [
   "pending",
   "graveyard",
   "wip",
+  // A custom status that indicates the beatmap was uploaded as a file.
+  // High scores are not recorded for local beatmaps.
   "local",
 ] as const;
 export type Status = (typeof STATUSES)[number];
@@ -48,6 +50,8 @@ export type Beatmap = {
 
   count_circles: number; // Tap note count
   count_sliders: number; // Hold note count
+
+  // Custom properties
   hash?: string;
 };
 
@@ -68,7 +72,7 @@ export type BeatmapSet = {
   // covers: Covers;
   creator: string;
   // favourite_count: number;
-  id: number;
+  id: number; // Set to 0 for local beatmaps if the set ID could not be found
   nsfw: boolean;
   offset: number;
   // play_count: number;
@@ -78,12 +82,14 @@ export type BeatmapSet = {
   // spotlight: boolean;
   title: string;
   title_unicode: string;
-  coverUrl?: string;
-  previewUrl?: string;
   // user_id: number;
   // video: boolean;
 
   beatmaps: Beatmap[];
+
+  // Custom properties
+  coverUrl?: string;
+  previewUrl?: string;
 };
 
 export async function getBeatmapSets({

--- a/src/lib/replay.ts
+++ b/src/lib/replay.ts
@@ -113,6 +113,7 @@ export async function downloadReplay(
 
 export function generateAutoReplay(
   beatmapData: BeatmapData,
+  hash: string,
   mods: Settings["mods"],
 ): ReplayDataV2 {
   const inputs: ReplayInputV2[] = [];
@@ -130,6 +131,7 @@ export function generateAutoReplay(
     version: 2,
     timestamp: Date.now(),
     beatmap: {
+      hash,
       id: beatmapData.beatmapId,
       setId: beatmapData.beatmapSetId,
     },

--- a/src/lib/replay.ts
+++ b/src/lib/replay.ts
@@ -8,6 +8,27 @@ import type { BeatmapData } from "./beatmapParser";
 import { getReplayFilename } from "./results";
 import { downloadBlob } from "./utils";
 
+export function normalizeReplayBeatmapReference(
+  replayData: ReplayData,
+): ReplayData {
+  const hasOnlineIds =
+    replayData.beatmap.id != null && replayData.beatmap.setId != null;
+
+  return {
+    ...replayData,
+    beatmap: hasOnlineIds
+      ? {
+          id: replayData.beatmap.id,
+          setId: replayData.beatmap.setId,
+        }
+      : {
+          hash: replayData.beatmap.hash,
+          version: replayData.beatmap.version,
+          keyCount: replayData.beatmap.keyCount,
+        },
+  };
+}
+
 const ModBits = {
   autoplay: 0,
   easy: 1,
@@ -85,7 +106,8 @@ export async function downloadReplay(
   }
 
   try {
-    const replayDataString = JSON.stringify(replayData);
+    const normalizedReplay = normalizeReplayBeatmapReference(replayData);
+    const replayDataString = JSON.stringify(normalizedReplay);
     const encoded = new TextEncoder().encode(replayDataString);
     const compressed = compressSync(encoded);
     const blob = new Blob([compressed as BlobPart], {

--- a/src/lib/replay.ts
+++ b/src/lib/replay.ts
@@ -12,27 +12,6 @@ import type { BeatmapData } from "./beatmapParser";
 import { getReplayFilename } from "./results";
 import { downloadBlob } from "./utils";
 
-export function normalizeReplayBeatmapReference(
-  replayData: ReplayData,
-): ReplayData {
-  const hasOnlineIds =
-    replayData.beatmap.id != null && replayData.beatmap.setId != null;
-
-  return {
-    ...replayData,
-    beatmap: hasOnlineIds
-      ? {
-          id: replayData.beatmap.id,
-          setId: replayData.beatmap.setId,
-        }
-      : {
-          hash: replayData.beatmap.hash,
-          version: replayData.beatmap.version,
-          keyCount: replayData.beatmap.keyCount,
-        },
-  };
-}
-
 const ModBits = {
   autoplay: 0,
   easy: 1,
@@ -110,8 +89,7 @@ export async function downloadReplay(
   }
 
   try {
-    const normalizedReplay = normalizeReplayBeatmapReference(replayData);
-    const replayDataString = JSON.stringify(normalizedReplay);
+    const replayDataString = JSON.stringify(replayData);
     const encoded = new TextEncoder().encode(replayDataString);
     const compressed = compressSync(encoded);
     const blob = new Blob([compressed as BlobPart], {

--- a/src/osuMania/systems/replayRecorder.ts
+++ b/src/osuMania/systems/replayRecorder.ts
@@ -6,12 +6,16 @@ import type { Game } from "../game";
 export type ReplayData = {
   /**
    * V1: fixes audio offset
+   * V2: added beatmap hash, version and keycount for beatmaps played with a local file
    */
   version: number;
   timestamp?: number;
   beatmap: {
-    id: number;
-    setId: number;
+    id?: number;
+    setId?: number;
+    hash?: string;
+    version?: string;
+    keyCount?: number;
   };
   mods: EncodedMods;
   inputs: ReplayInput[][];
@@ -30,10 +34,18 @@ export class ReplayRecorder {
     this.game = game;
 
     this.replayData = {
-      version: 1,
+      version: 2,
       beatmap: {
-        id: Number(beatmapData.beatmapId),
-        setId: beatmapData.beatmapSetId,
+        ...(beatmapData.isLocalSource
+          ? {
+              hash: beatmapData.beatmapHash,
+              version: beatmapData.metadata.version,
+              keyCount: beatmapData.difficulty.keyCount,
+            }
+          : {
+              id: Number(beatmapData.beatmapId),
+              setId: beatmapData.beatmapSetId,
+            }),
       },
       mods: encodeMods(this.game.mods),
       inputs: Array.from({ length: this.game.difficulty.keyCount }, () => []),

--- a/src/osuMania/systems/replayRecorder.ts
+++ b/src/osuMania/systems/replayRecorder.ts
@@ -3,15 +3,24 @@ import type { EncodedMods } from "@/lib/replay";
 import { encodeMods } from "@/lib/replay";
 import type { Game } from "../game";
 
+export type LocalBeatmapData = {
+  hash: string;
+
+  // For local beatmaps, don't rely on the beatmap ID / set ID as they may not exist.
+  // Instead, use the difficulty name and keycount
+  version: string;
+  keyCount: number;
+};
+
+export type ApiBeatmapData = {
+  hash: string;
+  id: number;
+  setId: number;
+};
+
 type BaseReplayData = {
   timestamp?: number;
-  beatmap: {
-    id?: number;
-    setId?: number;
-    hash?: string;
-    version?: string;
-    keyCount?: number;
-  };
+  beatmap: LocalBeatmapData | ApiBeatmapData;
   mods: EncodedMods;
   columnMap?: number[];
 };
@@ -43,20 +52,24 @@ export class ReplayRecorder {
   constructor(game: Game, beatmapData: BeatmapData) {
     this.game = game;
 
+    let beatmap: LocalBeatmapData | ApiBeatmapData;
+    if (beatmapData.isLocalSource) {
+      beatmap = {
+        hash: beatmapData.beatmapHash,
+        version: beatmapData.metadata.version,
+        keyCount: beatmapData.difficulty.keyCount,
+      };
+    } else {
+      beatmap = {
+        hash: beatmapData.beatmapHash,
+        id: Number(beatmapData.beatmapId),
+        setId: beatmapData.beatmapSetId,
+      };
+    }
+
     this.replayData = {
       version: 2,
-      beatmap: {
-        ...(beatmapData.isLocalSource
-          ? {
-              hash: beatmapData.beatmapHash,
-              version: beatmapData.metadata.version,
-              keyCount: beatmapData.difficulty.keyCount,
-            }
-          : {
-              id: Number(beatmapData.beatmapId),
-              setId: beatmapData.beatmapSetId,
-            }),
-      },
+      beatmap,
       mods: encodeMods(this.game.mods),
       inputs: [],
       columnMap: game.mods.random ? beatmapData.columnMap : undefined,

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1,23 +1,27 @@
-import { getBeatmapSetIdFromOsz } from "@/lib/beatmapParser";
+import { getBeatmapSetFromOsz } from "@/lib/beatmapParser";
 import type { BeatmapSet } from "@/lib/osuApi";
 import { getBeatmapSet } from "@/lib/osuApi";
-import { BASE_PATH } from "@/lib/utils";
 import { createSelectors } from "@/lib/zustand";
 import type { ReplayData } from "@/osuMania/systems/replayRecorder";
 import { Howler } from "howler";
-import queryString from "query-string";
 import { toast } from "sonner";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 
 type GameState = {
   uploadedBeatmapSet: File | null;
+  localReplayBeatmapSet: File | null;
   beatmapSet: BeatmapSet | null;
   beatmapId: number | null;
   replayData: ReplayData | null;
   scrollPosition: number | null;
   startGame: (beatmapId: number) => void;
   startReplay: (replay: ReplayData) => Promise<void>;
+  startLocalReplayWithBeatmap: (
+    replay: ReplayData,
+    file: File,
+    allowMismatch?: boolean,
+  ) => Promise<"started" | "mismatch" | "error">;
   setBeatmapSet: (beatmapSet: BeatmapSet | null) => void;
   closeGame: () => void;
   setUploadedBeatmapSet: (file: File | null) => void;
@@ -27,6 +31,7 @@ type GameState = {
 const useGameStoreBase = create<GameState>()(
   immer((set, get) => ({
     uploadedBeatmapSet: null,
+    localReplayBeatmapSet: null,
     beatmapSet: null,
     beatmapId: null,
     replayData: null,
@@ -43,15 +48,113 @@ const useGameStoreBase = create<GameState>()(
 
     startReplay: async (replay: ReplayData) => {
       const beatmapSetId = replay.beatmap.setId;
-      const beatmapId = Number(replay.beatmap.id);
+      const beatmapId = replay.beatmap.id;
+      const beatmapHash = replay.beatmap.hash;
 
-      const beatmapSet = await getBeatmapSet(beatmapSetId);
+      // Prefer online IDs when present (backward compatible with older replays
+      if (beatmapSetId != null && beatmapId != null) {
+        const beatmapSet = await getBeatmapSet(beatmapSetId);
 
-      set((state) => {
-        state.beatmapId = beatmapId;
-        state.beatmapSet = beatmapSet;
-        state.replayData = replay;
-      });
+        set((state) => {
+          state.localReplayBeatmapSet = null;
+          state.beatmapId = Number(beatmapId);
+          state.beatmapSet = beatmapSet;
+          state.replayData = replay;
+        });
+
+        return;
+      }
+
+      if (beatmapHash) {
+        const uploadedBeatmapSet = get().beatmapSet;
+
+        if (!uploadedBeatmapSet || uploadedBeatmapSet.status !== "local") {
+          toast(
+            "This replay requires the original local .osz beatmap. Upload the map first, then play the replay.",
+          );
+          return;
+        }
+
+        const localBeatmap = uploadedBeatmapSet.beatmaps.find(
+          (beatmap) => beatmap.hash === beatmapHash,
+        );
+
+        if (!localBeatmap) {
+          toast("Uploaded map does not match replay hash.");
+          return;
+        }
+
+        set((state) => {
+          state.localReplayBeatmapSet = null;
+          state.beatmapId = localBeatmap.id;
+          state.replayData = replay;
+        });
+
+        return;
+      }
+
+      toast("Replay is missing beatmap identifiers.");
+    },
+
+    startLocalReplayWithBeatmap: async (
+      replay: ReplayData,
+      file: File,
+      allowMismatch = false,
+    ) => {
+      const beatmapHash = replay.beatmap.hash;
+      if (!beatmapHash) {
+        toast("Replay is missing local beatmap hash.");
+        return "error";
+      }
+
+      try {
+        const beatmapSet = await getBeatmapSetFromOsz(file);
+        const localBeatmap = beatmapSet.beatmaps.find(
+          (beatmap) => beatmap.hash === beatmapHash,
+        );
+        const fallbackBeatmap =
+          beatmapSet.beatmaps.find(
+            (beatmap) =>
+              beatmap.version === replay.beatmap.version &&
+              beatmap.cs === replay.beatmap.keyCount,
+          ) ??
+          beatmapSet.beatmaps.find(
+            (beatmap) => beatmap.cs === replay.beatmap.keyCount,
+          ) ??
+          beatmapSet.beatmaps[0];
+
+        const selectedBeatmap = localBeatmap ?? fallbackBeatmap;
+
+        if (!selectedBeatmap) {
+          toast("Uploaded beatmap set has no playable mania difficulties.");
+          return "error";
+        }
+
+        if (!localBeatmap && !allowMismatch) {
+          return "mismatch";
+        }
+
+        const currentBeatmapSet = get().beatmapSet;
+        if (currentBeatmapSet?.coverUrl) {
+          URL.revokeObjectURL(currentBeatmapSet.coverUrl);
+        }
+        if (currentBeatmapSet?.previewUrl) {
+          URL.revokeObjectURL(currentBeatmapSet.previewUrl);
+        }
+
+        set((state) => {
+          state.uploadedBeatmapSet = null;
+          state.localReplayBeatmapSet = file;
+          state.beatmapSet = beatmapSet;
+          state.beatmapId = selectedBeatmap.id;
+          state.replayData = replay;
+        });
+
+        return "started";
+      } catch (error: any) {
+        toast(error.message || "Failed to parse beatmap set from .osz file.");
+        return "error";
+      }
     },
 
     closeGame: () => {
@@ -60,6 +163,7 @@ const useGameStoreBase = create<GameState>()(
       set((state) => {
         state.beatmapId = null;
         state.replayData = null;
+        state.localReplayBeatmapSet = null;
 
         // If playing from an uploaded file, leave beatmapSet so the upload dialog stays open
         if (!state.uploadedBeatmapSet) {
@@ -69,38 +173,35 @@ const useGameStoreBase = create<GameState>()(
     },
 
     setUploadedBeatmapSet: async (file: File | null) => {
+      const currentBeatmapSet = get().beatmapSet;
+      if (currentBeatmapSet?.coverUrl) {
+        URL.revokeObjectURL(currentBeatmapSet.coverUrl);
+      }
+      if (currentBeatmapSet?.previewUrl) {
+        URL.revokeObjectURL(currentBeatmapSet.previewUrl);
+      }
+
       set((state) => {
+        state.localReplayBeatmapSet = null;
         state.uploadedBeatmapSet = file;
       });
 
       if (file) {
-        const beatmapSetId = await getBeatmapSetIdFromOsz(file);
+        try {
+          const beatmapSet = await getBeatmapSetFromOsz(file);
 
-        // Fetch beatmap set data from osu (cover BG, preview audio, diff star ratings, etc.)
-        // Theoretically I could do this manually but that's too much work :<
-        const url = queryString.stringifyUrl({
-          url: `${BASE_PATH}/api/getBeatmap`,
-          query: { beatmapSetId },
-        });
-
-        const beatmapSetRes = await fetch(url);
-
-        if (!beatmapSetRes.ok) {
+          set((state) => {
+            state.beatmapSet = beatmapSet;
+          });
+        } catch (error: any) {
           set((state) => {
             state.uploadedBeatmapSet = null;
           });
 
-          const message = await beatmapSetRes.text();
-          toast(message);
+          toast(error.message || "Failed to parse beatmap set from .osz file.");
 
           return;
         }
-
-        const beatmapSet: BeatmapSet = await beatmapSetRes.json();
-
-        set((state) => {
-          state.beatmapSet = beatmapSet;
-        });
       } else {
         set((state) => {
           state.beatmapSet = null;

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -2,7 +2,10 @@ import { getBeatmapSetFromOsz } from "@/lib/beatmapParser";
 import type { BeatmapSet } from "@/lib/osuApi";
 import { getBeatmapSet } from "@/lib/osuApi";
 import { createSelectors } from "@/lib/zustand";
-import type { ReplayData } from "@/osuMania/systems/replayRecorder";
+import type {
+  LocalBeatmapData,
+  ReplayData,
+} from "@/osuMania/systems/replayRecorder";
 import { Howler } from "howler";
 import { toast } from "sonner";
 import { create } from "zustand";
@@ -47,11 +50,11 @@ const useGameStoreBase = create<GameState>()(
     },
 
     startReplay: async (replay: ReplayData) => {
-      const beatmapSetId = replay.beatmap.setId;
-      const beatmapId = replay.beatmap.id;
-      const beatmapHash = replay.beatmap.hash;
+      const beatmapSetId =
+        "setId" in replay.beatmap ? replay.beatmap.setId : undefined;
+      const beatmapId = "id" in replay.beatmap ? replay.beatmap.id : undefined;
 
-      // Prefer online IDs when present (backward compatible with older replays
+      // Prefer online IDs when present
       if (beatmapSetId != null && beatmapId != null) {
         const beatmapSet = await getBeatmapSet(beatmapSetId);
 
@@ -65,6 +68,7 @@ const useGameStoreBase = create<GameState>()(
         return;
       }
 
+      const beatmapHash = replay.beatmap.hash;
       if (beatmapHash) {
         const uploadedBeatmapSet = get().beatmapSet;
 
@@ -112,14 +116,17 @@ const useGameStoreBase = create<GameState>()(
         const localBeatmap = beatmapSet.beatmaps.find(
           (beatmap) => beatmap.hash === beatmapHash,
         );
+
+        const replayBeatmapData = replay.beatmap as LocalBeatmapData;
+
         const fallbackBeatmap =
           beatmapSet.beatmaps.find(
             (beatmap) =>
-              beatmap.version === replay.beatmap.version &&
-              beatmap.cs === replay.beatmap.keyCount,
+              beatmap.version === replayBeatmapData.version &&
+              beatmap.cs === replayBeatmapData.keyCount,
           ) ??
           beatmapSet.beatmaps.find(
-            (beatmap) => beatmap.cs === replay.beatmap.keyCount,
+            (beatmap) => beatmap.cs === replayBeatmapData.keyCount,
           ) ??
           beatmapSet.beatmaps[0];
 


### PR DESCRIPTION
Resolves #222 
---
Uploaded Beatmaps no longer use the osu API to pull level data.
Everything is imported from the uploaded .osz file, even if there is a beatmap ID present.
In the difficulty select menu, the cover and audio file used for the sample are taken from the 1st .osu file found.
The star rating calculation is based on the osu source code, and comparing the local result with the server result, I’ve only seen a 0.01 margin of error.

When a map is played from a local copy, high scores/replays are not saved in the browser. However, replays can still be saved and viewed later.
Replays can now store beatmap hashes with the diff played.

When a map is played from the API, the beatmap ID and setID are attached to the replay, and when it’s played back, it takes the beatmap from the API.
When a map is played from a local file, the beatmap hash and diff are attached to the replay. When it’s played back, the user is asked to upload the beatmap used to make the replay, then the hash of the uploaded beatmap is calculated.
* If the hashes match, we go to the replay playback.
* If the hashes are not a match, we show a new dialogue box explaining that they don’t match and the replay might be inconsistent, but the user can proceed by clicking ‘okay.’

Replays that have been created before this change will still work.

---

`npx eslint` and `npm run build` ran successfully
The references for the star difficulty calculations can be found in [src/lib/maniaDifficulty.ts](https://github.com/Slingexe/Web-Osu-Mania/blob/issue/222/src/lib/maniaDifficulty.ts)