### PR TITLE
lane width percent, bg color, note scale 0.1

### DIFF
--- a/src/components/settings/settingsTab.tsx
+++ b/src/components/settings/settingsTab.tsx
@@ -1,6 +1,13 @@
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { capitalizeFirstLetter } from "@/lib/utils";
 import { MAX_TIME_RANGE } from "@/osuMania/constants";
 import { PersonStanding } from "lucide-react";
+import { HslStringColorPicker } from "react-colorful";
 import type {
   EarlyLateThreshold,
   JudgementCounterPosition,
@@ -36,6 +43,7 @@ import VolumeSettings from "./volumeSettings";
 const SettingsTab = () => {
   const setSettings = useSettingsStore.use.setSettings();
   const resetSettings = useSettingsStore.use.resetSettings();
+  const laneBackgroundColor = useSettingsStore((s) => s.laneBackgroundColor);
 
   return (
     <>
@@ -60,6 +68,18 @@ const SettingsTab = () => {
           max={360}
           step={1}
         />
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline" className="w-full justify-start gap-2">
+              <span className="border-input size-4 shrink-0 rounded-full border" style={{ backgroundColor: laneBackgroundColor }} />
+              Lane Background Color
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-fit">
+            <HslStringColorPicker color={laneBackgroundColor} onChange={(c) => setSettings((d) => { d.laneBackgroundColor = c })} />
+          </PopoverContent>
+        </Popover>
 
         <SwitchInput
           label="Prefer Metadata in Original Language"
@@ -377,7 +397,7 @@ const SettingsTab = () => {
               draft.noteScale = receptorScale;
             })
           }
-          min={0.5}
+          min={0.1}
           max={1}
           step={0.01}
         />
@@ -387,18 +407,18 @@ const SettingsTab = () => {
         </p>
 
         <SliderInput
-          label="Lane Width Adjustment"
+          label="Lane Width"
           settingPath="laneWidthAdjustment"
           tooltip={(laneWidthAdjustment) =>
-            `${Math.round(laneWidthAdjustment)}px`
+            `${Math.round(laneWidthAdjustment)}%`
           }
           onValueChange={([laneWidthAdjustment]) =>
             setSettings((draft) => {
               draft.laneWidthAdjustment = laneWidthAdjustment;
             })
           }
-          min={-20}
-          max={80}
+          min={5}
+          max={100}
           step={1}
         />
         <SliderInput

--- a/src/osuMania/game.ts
+++ b/src/osuMania/game.ts
@@ -8,7 +8,7 @@ import type {
   TimingPoint,
 } from "@/lib/beatmapParser";
 import { decodeMods } from "@/lib/replay";
-import { BASE_PATH, scaleWidth } from "@/lib/utils";
+import { BASE_PATH } from "@/lib/utils";
 import type { ColumnColor, Settings } from "@/stores/settingsStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import type { Column, GameState, PlayResults } from "@/types";
@@ -20,6 +20,7 @@ import * as PIXI from "pixi.js";
 import {
   Application,
   BitmapText,
+  Color,
   Container,
   FillGradient,
   Graphics,
@@ -32,7 +33,6 @@ import {
   MAX_TIME_RANGE,
   getAllLaneColors,
   laneArrowDirections,
-  laneWidths,
 } from "./constants";
 import { Countdown } from "./sprites/countdown";
 import { ErrorBar } from "./sprites/errorBar";
@@ -42,6 +42,7 @@ import { ArrowHold } from "./sprites/hold/arrowHold";
 import { BarHold } from "./sprites/hold/barHold";
 import { CircleHold } from "./sprites/hold/circleHold";
 import { DiamondHold } from "./sprites/hold/diamondHold";
+import { Hold } from "./sprites/hold/hold";
 import { Judgement } from "./sprites/judgement";
 import { JudgementCounter } from "./sprites/judgementCounter";
 import { ArrowKey } from "./sprites/key/arrowKey";
@@ -455,11 +456,10 @@ export class Game {
 
     this.hitPosition = this.app.screen.height - this.hitPositionOffset;
 
-    this.scaledColumnWidth = scaleWidth(
-      laneWidths[this.difficulty.keyCount - 1] +
-        this.settings.laneWidthAdjustment,
-      this.app.screen.width,
-    );
+    this.scaledColumnWidth =
+      (this.settings.laneWidthAdjustment / 100) *
+      this.app.screen.width /
+      this.difficulty.keyCount;
 
     // Cap column width on small screen widths
     if (
@@ -824,7 +824,7 @@ export class Game {
   private addStageContainer() {
     this.stageBackground = new Graphics()
       .rect(0, 0, this.notesContainerWidth, this.app.screen.height)
-      .fill(0x111111);
+      .fill(new Color(this.settings.laneBackgroundColor).toNumber());
     this.stageBackground.alpha = this.settings.stageOpacity;
     this.notesContainer.addChild(this.stageBackground);
 
@@ -996,6 +996,9 @@ export class Game {
     for (const column of this.columns) {
       for (const hitObject of column) {
         hitObject.view.visible = false;
+        if (hitObject instanceof Hold) {
+          hitObject.resetHeight();
+        }
       }
     }
 

--- a/src/osuMania/sprites/hold/hold.ts
+++ b/src/osuMania/sprites/hold/hold.ts
@@ -76,6 +76,13 @@ export abstract class Hold {
 
   public hit() {}
 
+  public resetHeight() {
+    this.view.visible = true;
+    this.setViewHeight(
+      this.game.getHitObjectOffset(this.data.time, this.getVisualEndTime()),
+    );
+  }
+
   public release(timeElapsedOverride?: number) {
     const timeElapsed = timeElapsedOverride ?? this.game.timeElapsed;
     const endTimeDelta = this.data.endTime - timeElapsed;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -185,6 +185,7 @@ export type Settings = {
   retryOnFail: boolean;
   performanceMode: boolean;
   hue: number;
+  laneBackgroundColor: string;
   stagePosition: number;
   stageOpacity: number;
   stageSidesOpacity: number;
@@ -299,10 +300,11 @@ export const defaultSettings: Settings = {
   retryOnFail: false,
   performanceMode: false,
   hue: 212,
+  laneBackgroundColor: "hsl(0, 0%, 7%)",
   stagePosition: 0,
   stageOpacity: 0.5,
   stageSidesOpacity: 1,
-  laneWidthAdjustment: 0,
+  laneWidthAdjustment: 50,
   laneSpacing: 0,
   touch: {
     enabled: true,


### PR DESCRIPTION
- uses % instead of px for lane width (allows 5-100% (wider range))
- custom lane background (new storage, check if new input field fits aesthetics)
- min 50% -> 10% note scale (for wide screens with 100% width)

> please double-check. this PR might be rushed.